### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/de.manuel_kehl.go-for-it.yml
+++ b/de.manuel_kehl.go-for-it.yml
@@ -56,6 +56,8 @@ modules:
         commit: b7c39dc45a0d89fadbaeac1b64a1bf6e497e875f
       - type: patch
         path: build-fix.patch
+      - type: patch
+        path: fix-appdata.patch
     post-install:
       - install -Dm644 -t /app/share/licenses/de.manuel_kehl.go-for-it ../COPYING
       # workaround for non-png-icon-in-hicolor-size-folder lint error

--- a/de.manuel_kehl.go-for-it.yml
+++ b/de.manuel_kehl.go-for-it.yml
@@ -58,3 +58,7 @@ modules:
         path: build-fix.patch
     post-install:
       - install -Dm644 -t /app/share/licenses/de.manuel_kehl.go-for-it ../COPYING
+      # workaround for non-png-icon-in-hicolor-size-folder lint error
+      - mkdir -p /app/share/icons/hicolor/scalable/apps
+      - mv /app/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - find /app/share/icons/hicolor -type f -not -path "*scalable*" -not -path "*actions*" -name "*.svg" -delete

--- a/de.manuel_kehl.go-for-it.yml
+++ b/de.manuel_kehl.go-for-it.yml
@@ -1,6 +1,6 @@
 id: de.manuel_kehl.go-for-it
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: de.manuel_kehl.go-for-it
 finish-args:

--- a/de.manuel_kehl.go-for-it.yml
+++ b/de.manuel_kehl.go-for-it.yml
@@ -13,11 +13,9 @@ finish-args:
   - --socket=pulseaudio
   # Access user files
   - --filesystem=home
-
-  # Ayatana indicator plugin
-  - --talk-name=org.kde.*
   # LauncherEntry indicator plugin
   - --talk-name=com.canonical.Unity.LauncherEntry
+  - --talk-name=org.kde.StatusNotifierWatcher
 cleanup:
   - '*.a'
   - '*.h'

--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,63 @@
+From e1c458e39f9aee6ca7f5741ae94b8cd79ecd1b43 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sat, 16 Nov 2024 17:47:15 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+---
+ data/go-for-it.appdata.xml.in.in | 34 ++++------------------------------
+ 1 file changed, 4 insertions(+), 30 deletions(-)
+
+diff --git a/data/go-for-it.appdata.xml.in.in b/data/go-for-it.appdata.xml.in.in
+index a0af5d7..a6d588b 100644
+--- a/data/go-for-it.appdata.xml.in.in
++++ b/data/go-for-it.appdata.xml.in.in
+@@ -20,8 +20,10 @@ To-do lists are stored in the Todo.txt format. This simplifies synchronization w
+       <image>https://raw.githubusercontent.com/JMoerman/Go-For-It/master/screenshot.png</image>
+     </screenshot>
+   </screenshots>
++  <launchable type="desktop-id">de.manuel_kehl.go-for-it.desktop</launchable>
+   <url type="homepage">https://jmoerman.github.io/go-for-it/</url>
+   <url type="bugtracker">https://github.com/JMoerman/Go-For-It/issues</url>
++  <url type="vcs-browser">https://github.com/JMoerman/Go-For-It</url>
+   <url type="help">https://github.com/JMoerman/Go-For-It/blob/master/README.md</url>
+   <url type="translate">https://hosted.weblate.org/projects/go-for-it/</url>
+   <url type="donation">https://jmoerman.github.io/donate/</url>
+@@ -269,33 +271,5 @@ To-do lists are stored in the Todo.txt format. This simplifies synchronization w
+       </description>
+     </release>
+   </releases>
+-  <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
+-</component>
++  <content_rating type="oars-1.1"/>
++ </component>
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- GNOME runtime version 45 has reached EOL.
- Workaround for non-png-icon-in-hicolor-size-folder lint
